### PR TITLE
feat(args): support double splat arg

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,9 +1,9 @@
 name: inactive-support
-version: 0.1.0
+version: 0.1.1
 
 authors:
   - Kim Burgess <kim@place.technology>
 
-crystal: 0.34.0
+crystal: ~> 0.34
 
 license: MIT

--- a/spec/macro/args_spec.cr
+++ b/spec/macro/args_spec.cr
@@ -5,10 +5,19 @@ def args_test(a, b, c)
   args
 end
 
+def args_test2(d, **e)
+  args
+end
+
 describe "macro/args" do
   it "creates a NamedTuple from surround args" do
     result = args_test "foo", "bar", "baz"
     result.should eq({a: "foo", b: "bar", c: "baz"})
+  end
+
+  it "includes the double splat arg if it exists" do
+    result = args_test2 "test", hello: "world"
+    result.should eq({d: "test", e: {hello: "world"}})
   end
 end
 

--- a/src/macro/args.cr
+++ b/src/macro/args.cr
@@ -7,7 +7,9 @@ macro args
     {% raise "args macro can only be used within a method" if @def.is_a? NilLiteral %}
     {% begin %}
     {
-      {% for arg in @def.args %}
+      {% args = @def.args %}
+      {% args << @def.double_splat if @def.double_splat %}
+      {% for arg in args %}
         {{arg.internal_name.id}}: {{arg.internal_name}},
       {% end %}
     }


### PR DESCRIPTION
Minor update to support variadic (double splat) args.