### PR TITLE
fix: add crystal 1.0.0 support

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,6 +1,6 @@
 name: inactive-support
-crystal: ">= 0.34.0"
-version: 0.1.2
+crystal: ">= 0.36.0"
+version: 0.2.0
 license: MIT
 
 authors:

--- a/shard.yml
+++ b/shard.yml
@@ -1,9 +1,7 @@
 name: inactive-support
-version: 0.1.1
+crystal: ">= 0.34.0"
+version: 0.1.2
+license: MIT
 
 authors:
   - Kim Burgess <kim@place.technology>
-
-crystal: ~> 0.34
-
-license: MIT

--- a/src/collection.cr
+++ b/src/collection.cr
@@ -240,8 +240,34 @@ struct YAML::Any
   end
 end
 
+module Digable
+  def dig(key : K, *subkeys)
+    if (value = self[key]) && value.responds_to?(:dig)
+      return value.dig(*subkeys)
+    end
+    raise KeyError.new "#{self.class} value not diggable for key: #{key.inspect}"
+  end
+
+  # :nodoc:
+  def dig(key : K)
+    self[key]
+  end
+
+  def dig?(key : K, *subkeys)
+    if (value = self[key]?) && value.responds_to?(:dig?)
+      value.dig?(*subkeys)
+    end
+  end
+
+  # :nodoc:
+  def dig?(key : K)
+    self[key]?
+  end
+end
+
 class HTTP::Cookies
   include Collection(String, HTTP::Cookie)
+  include Digable
 
   def each_pair(&block) : Nil
     each { |c| yield({c.name, c}) }
@@ -254,6 +280,7 @@ end
 
 struct HTTP::Headers
   include Collection(String, Array(String))
+  include Digable
 
   def each_pair(&block) : Nil
     each { |k, v| yield({k, v}) }
@@ -266,6 +293,7 @@ end
 
 struct HTTP::Params
   include Collection(String, String)
+  include Digable
 
   def each_pair(&block) : Nil
     each { |k, v| yield({k, v}) }


### PR DESCRIPTION
dig methods required for the HTTP classes
might be able to improve on these where header and possibly params could return an array for example, although this is probably an edge case?
