### PR TITLE
Mapped enum

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,20 +72,16 @@ example "foo", "bar", "baz" # => {a: "foo", b: "bar", c: "baz"}
 
 ### `macro/mapped_enum`
 
-Provides a lightweight syntax for defining non-integer enum types.
+Provides support for defining non-integer enum types.
 ```crystal
-mapped_enum Example(String),
-  A = "foo",
-  B = "bar",
+mapped_enum Example do
+  A = "foo"
+  B = "bar"
   C = "baz"
+end
 ```
-The type may be optionally ommitted, but is recommended for increased compile-time safety.
 
 Instances may be read from mapped values
-```crystal
-Example.from_mapped_value "foo" # => Example::A
-```
-or
 ```crystal
 Example["foo"] # => Example::A
 ```

--- a/README.md
+++ b/README.md
@@ -68,3 +68,35 @@ end
 
 example "foo", "bar", "baz" # => {a: "foo", b: "bar", c: "baz"}
 ```
+
+
+### `macro/mapped_enum`
+
+Provides a lightweight syntax for defining non-integer enum types.
+```crystal
+mapped_enum Example(String),
+  A = "foo",
+  B = "bar",
+  C = "baz"
+```
+The type may be optionally ommitted, but is recommended for increased compile-time safety.
+
+Instances may be read from mapped values
+```crystal
+Example.from_mapped_value "foo" # => Example::A
+```
+or
+```crystal
+Example["foo"] # => Example::A
+```
+
+Mapped values may also be extracted
+```crystal
+Example::A.mapped_value # => "foo"
+```
+or
+```crystal
+~Example::A # => "foo"
+```
+
+All other functionality and safety that enums provide holds.

--- a/README.md
+++ b/README.md
@@ -81,9 +81,21 @@ mapped_enum Example do
 end
 ```
 
-Instances may be read from mapped values
+Members may be accessed via a compile-time lookup from their mapped value
 ```crystal
 Example["foo"] # => Example::A
+```
+
+Attempting static resolution for an unmapped value will result in a compile error
+```crystal
+Example["qux"]
+
+Error: No mapping defined from "qux" to Example
+```
+
+Instances may be read dynamically
+```crystal
+Example.from_mapped_value "foo" # => Example::A
 ```
 
 Mapped values may also be extracted

--- a/README.md
+++ b/README.md
@@ -94,9 +94,5 @@ Mapped values may also be extracted
 ```crystal
 Example::A.mapped_value # => "foo"
 ```
-or
-```crystal
-~Example::A # => "foo"
-```
 
 All other functionality and safety that enums provide holds.

--- a/shard.yml
+++ b/shard.yml
@@ -1,6 +1,6 @@
 name: inactive-support
 crystal: ">= 0.36.0"
-version: 0.2.0
+version: 0.3.0
 license: MIT
 
 authors:

--- a/spec/macro/mapped_enum_spec.cr
+++ b/spec/macro/mapped_enum_spec.cr
@@ -1,0 +1,94 @@
+require "spec"
+require "../../src/macro/mapped_enum"
+
+mapped_enum SpecStrictMappedEnum(String),
+  A = "foo",
+  B = "bar",
+  C = "baz"
+
+mapped_enum SpecMappedEnum,
+  A = "foo",
+  B = "bar",
+  C = "baz"
+
+describe "macro/mapped_enum" do
+  {% for type in [SpecStrictMappedEnum, SpecMappedEnum] %}
+    describe {{type.stringify}} do
+      it "defines an enum type" do
+        ({{type}} < Enum).should be_true
+      end
+
+      describe ".from_mapped_value" do
+        it "reads into a known mapped value" do
+          {{type}}.from_mapped_value("foo").should eq {{type}}::A
+        end
+
+        it "yields if no matching member exists" do
+          yielded = false
+          result = {{type}}.from_mapped_value("qux") do
+            yielded = true
+            {{type}}::A
+          end
+          yielded.should be_true
+          result.a?.should be_true
+        end
+
+        it "raises if no matching member exists and no block is passed" do
+          expect_raises(Exception) do
+            {{type}}.from_mapped_value("qux")
+          end
+        end
+      end
+
+      describe ".[]" do
+        it "reads into a known mapped value" do
+          {{type}}["foo"].should eq {{type}}::A
+        end
+
+        it "raises if no matching member exists and no block is passed" do
+          expect_raises(Exception) do
+            {{type}}["qux"]
+          end
+        end
+      end
+
+      describe ".from_mapped_value?" do
+        it "reads into a known mapped value" do
+          {{type}}.from_mapped_value?("foo").should eq {{type}}::A
+        end
+
+        it "returns nil if no matching member exists" do
+          {{type}}.from_mapped_value?("qux").should be_nil
+        end
+      end
+
+      describe ".[]?" do
+        it "reads into a known mapped value" do
+          {{type}}["foo"]?.should eq {{type}}::A
+        end
+
+        it "returns nil if no matching member exists" do
+          {{type}}["qux"]?.should be_nil
+        end
+      end
+
+      describe ".mapped_values" do
+        it "provides a Tuple of mapped values" do
+          {{type}}.mapped_values.should eq({"foo", "bar", "baz"})
+        end
+      end
+
+      describe "#mapped_value" do
+        it "returns the mapped value" do
+          {{type}}::A.mapped_value.should eq "foo"
+        end
+      end
+
+      describe "#~" do
+        it "returns the mapped value" do
+          (~{{type}}::A).should eq "foo"
+        end
+      end
+    end
+  {% end %}
+end

--- a/spec/macro/mapped_enum_spec.cr
+++ b/spec/macro/mapped_enum_spec.cr
@@ -1,88 +1,49 @@
 require "spec"
 require "../../src/macro/mapped_enum"
 
-mapped_enum SpecStrictMappedEnum(String),
-  A = "foo",
-  B = "bar",
+mapped_enum SpecMappedEnum do
+  A = "foo"
+  B = "bar"
   C = "baz"
-
-mapped_enum SpecMappedEnum,
-  A = "foo",
-  B = "bar",
-  C = "baz"
+end
 
 describe "macro/mapped_enum" do
-  {% for type in [SpecStrictMappedEnum, SpecMappedEnum] %}
-    describe {{type.stringify}} do
-      it "defines an enum type" do
-        ({{type}} < Enum).should be_true
-      end
+  it "defines an enum type" do
+    (SpecMappedEnum < Enum).should be_true
+  end
 
-      describe ".from_mapped_value" do
-        it "reads into a known mapped value" do
-          {{type}}.from_mapped_value("foo").should eq {{type}}::A
-        end
+  describe ".[]" do
+    it "reads into a known mapped value" do
+      SpecMappedEnum["foo"].should eq SpecMappedEnum::A
+    end
 
-        it "yields if no matching member exists" do
-          yielded = false
-          result = {{type}}.from_mapped_value("qux") do
-            yielded = true
-            {{type}}::A
-          end
-          yielded.should be_true
-          result.a?.should be_true
-        end
-
-        it "raises if no matching member exists and no block is passed" do
-          expect_raises(Exception) do
-            {{type}}.from_mapped_value("qux")
-          end
-        end
-      end
-
-      describe ".[]" do
-        it "reads into a known mapped value" do
-          {{type}}["foo"].should eq {{type}}::A
-        end
-
-        it "raises if no matching member exists and no block is passed" do
-          expect_raises(Exception) do
-            {{type}}["qux"]
-          end
-        end
-      end
-
-      describe ".from_mapped_value?" do
-        it "reads into a known mapped value" do
-          {{type}}.from_mapped_value?("foo").should eq {{type}}::A
-        end
-
-        it "returns nil if no matching member exists" do
-          {{type}}.from_mapped_value?("qux").should be_nil
-        end
-      end
-
-      describe ".[]?" do
-        it "reads into a known mapped value" do
-          {{type}}["foo"]?.should eq {{type}}::A
-        end
-
-        it "returns nil if no matching member exists" do
-          {{type}}["qux"]?.should be_nil
-        end
-      end
-
-      describe ".mapped_values" do
-        it "provides a Tuple of mapped values" do
-          {{type}}.mapped_values.should eq({"foo", "bar", "baz"})
-        end
-      end
-
-      describe "#mapped_value" do
-        it "returns the mapped value" do
-          {{type}}::A.mapped_value.should eq "foo"
-        end
+    it "raises if no matching member exists and no block is passed" do
+      expect_raises(Exception) do
+        SpecMappedEnum["qux"]
       end
     end
-  {% end %}
+  end
+
+  describe ".[]?" do
+    it "reads into a known mapped value" do
+      SpecMappedEnum["foo"]?.should eq SpecMappedEnum::A
+    end
+
+    it "returns nil if no matching member exists" do
+      SpecMappedEnum["qux"]?.should be_nil
+    end
+  end
+
+  describe ".mapped_values" do
+    it "provides a Tuple of mapped values" do
+      SpecMappedEnum.mapped_values.should eq(["foo", "bar", "baz"])
+    end
+  end
+
+  describe "#mapped_value" do
+    it "returns the mapped value" do
+      SpecMappedEnum::A.mapped_value.should eq "foo"
+    end
+  end
 end
+

--- a/spec/macro/mapped_enum_spec.cr
+++ b/spec/macro/mapped_enum_spec.cr
@@ -83,12 +83,6 @@ describe "macro/mapped_enum" do
           {{type}}::A.mapped_value.should eq "foo"
         end
       end
-
-      describe "#~" do
-        it "returns the mapped value" do
-          (~{{type}}::A).should eq "foo"
-        end
-      end
     end
   {% end %}
 end

--- a/spec/macro/mapped_enum_spec.cr
+++ b/spec/macro/mapped_enum_spec.cr
@@ -5,6 +5,14 @@ mapped_enum SpecMappedEnum do
   A = "foo"
   B = "bar"
   C = "baz"
+
+  def instance_test
+    "hello"
+  end
+
+  def self.class_test
+    42
+  end
 end
 
 describe "macro/mapped_enum" do
@@ -45,5 +53,12 @@ describe "macro/mapped_enum" do
       SpecMappedEnum::A.mapped_value.should eq "foo"
     end
   end
-end
 
+  it "places instance methods in the created type" do
+    SpecMappedEnum::A.instance_test.should eq "hello"
+  end
+
+  it "places class method in the created type" do
+    SpecMappedEnum.class_test.should eq 42
+  end
+end

--- a/spec/macro/mapped_enum_spec.cr
+++ b/spec/macro/mapped_enum_spec.cr
@@ -15,50 +15,64 @@ mapped_enum SpecMappedEnum do
   end
 end
 
+SpecMappedEnumLookupTest = "foo"
+
 describe "macro/mapped_enum" do
   it "defines an enum type" do
     (SpecMappedEnum < Enum).should be_true
-  end
-
-  describe ".[]" do
-    it "reads into a known mapped value" do
-      SpecMappedEnum["foo"].should eq SpecMappedEnum::A
-    end
-
-    it "raises if no matching member exists and no block is passed" do
-      expect_raises(Exception) do
-        SpecMappedEnum["qux"]
-      end
-    end
-  end
-
-  describe ".[]?" do
-    it "reads into a known mapped value" do
-      SpecMappedEnum["foo"]?.should eq SpecMappedEnum::A
-    end
-
-    it "returns nil if no matching member exists" do
-      SpecMappedEnum["qux"]?.should be_nil
-    end
-  end
-
-  describe ".mapped_values" do
-    it "provides a Tuple of mapped values" do
-      SpecMappedEnum.mapped_values.should eq(["foo", "bar", "baz"])
-    end
-  end
-
-  describe "#mapped_value" do
-    it "returns the mapped value" do
-      SpecMappedEnum::A.mapped_value.should eq "foo"
-    end
   end
 
   it "places instance methods in the created type" do
     SpecMappedEnum::A.instance_test.should eq "hello"
   end
 
-  it "places class method in the created type" do
+  it "places class methods in the created type" do
     SpecMappedEnum.class_test.should eq 42
+  end
+
+  describe "[]" do
+    it "provides compile-time resolution from a direct value" do
+      SpecMappedEnum["foo"].should eq SpecMappedEnum::A
+    end
+
+    it "provides compile-time resolution from a resolvable Path" do
+      SpecMappedEnum[SpecMappedEnumLookupTest].should eq SpecMappedEnum::A
+    end
+  end
+
+  describe Enum do
+    describe ".mapped_values" do
+      it "provides a Tuple of mapped values" do
+        SpecMappedEnum.mapped_values.should eq({"foo", "bar", "baz"})
+      end
+    end
+
+    describe ".from_mapped_value" do
+      it "reads into a known mapped value" do
+        SpecMappedEnum.from_mapped_value("foo").should eq SpecMappedEnum::A
+      end
+
+      it "raises if no matching member exists and no block is passed" do
+        expect_raises(Exception) do
+          SpecMappedEnum.from_mapped_value("qux")
+        end
+      end
+    end
+
+    describe ".from_mapped_value?" do
+      it "reads into a known mapped value" do
+        SpecMappedEnum.from_mapped_value?("foo").should eq SpecMappedEnum::A
+      end
+
+      it "returns nil if no matching member exists" do
+        SpecMappedEnum.from_mapped_value?("qux").should be_nil
+      end
+    end
+
+    describe "#mapped_value" do
+      it "returns the mapped value" do
+        SpecMappedEnum::A.mapped_value.should eq "foo"
+      end
+    end
   end
 end

--- a/src/macro/mapped_enum.cr
+++ b/src/macro/mapped_enum.cr
@@ -3,6 +3,9 @@
 struct Enum::Mapping(T, U)
   def initialize(enum_type : T.class, @values : Indexable(U)); end
 
+  # Mapped values, where indicies are `T.value`.
+  getter values
+
   # Returns the enum member that has the given mapped value, or yields if no such
   # member exists.
   def from_mapped_value(x : U, & : U -> V) : T | V forall V
@@ -23,11 +26,6 @@ struct Enum::Mapping(T, U)
   # member exists.
   def []?(x : U) : T?
     from_mapped_value(x) { nil }
-  end
-
-  # Returns the list of all mapped values.
-  def values : Indexable(U)
-    @values
   end
 
   # Returns the mapped value for the enum member.

--- a/src/macro/mapped_enum.cr
+++ b/src/macro/mapped_enum.cr
@@ -69,7 +69,7 @@ macro mapped_enum(name, &block)
     {% body_type = "#{enum_type}__body".id %}
     {% mapping = "#{enum_type}__mapping".id %}
 
-    module {{body_type}}
+    private module {{body_type}}
       {{block.body}}
     end
 
@@ -93,6 +93,14 @@ macro mapped_enum(name, &block)
       def mapped_value
         {{mapping}}.mapped_value self.value
       end
+
+      \{% for method in {{body_type}}.class.methods %}
+        \{{method.id}}
+      \{% end %}
+
+      \{% for method in {{body_type}}.methods %}
+        \{{method.id}}
+      \{% end %}
     end
 
     private {{mapping}} = Enum::Mapping.new {{enum_type}}, \{{ {{body_type}}.constants.map { |t| "{{body_type}}::#{t}".id } }}

--- a/src/macro/mapped_enum.cr
+++ b/src/macro/mapped_enum.cr
@@ -30,9 +30,9 @@ struct Enum::Mapping(T, U)
     @values
   end
 
-  # Returns the mapped value for the enum member at the given value.
-  def mapped_value(i : Int) : U
-    values[i]
+  # Returns the mapped value for the enum member.
+  def mapped_value(x : T) : U
+    values[x.value]
   end
 end
 
@@ -88,7 +88,7 @@ macro mapped_enum(name, &block)
       end
 
       def mapped_value
-        {{mapping}}.mapped_value self.value
+        {{mapping}}.mapped_value self
       end
 
       \{% for method in {{body_type}}.class.methods %}

--- a/src/macro/mapped_enum.cr
+++ b/src/macro/mapped_enum.cr
@@ -1,32 +1,5 @@
-# Defines a enum where each member holds a reference to an associated value.
-#
-# This may be used to define enum over non-integer types, whilst keeping the
-# same type safety that integer-backed enums provide.
-#
-# ```
-# mapped_enum Example(String),
-#   A = "foo",
-#   B = "bar",
-#   C = "baz"
-# ```
-#
-# Instances may be read from mapped values
-# ```
-# Example.from_mapped_value "foo" # => Example::A
-# ```
-#
-# A short-form syntax is also available for this
-# ```
-# Example["foo"] # => Example::A
-# ```
-#
-# Mapped values may also be extracted
-# ```
-# Example::A.mapped_value # => "foo"
-# ```
-#
-# All other functionality, performance and safety that enums provide holds.
-
+# Struct for associating an enum with a set of arbitrary values - one for each
+# member.
 struct Enum::Mapping(T, U)
   def initialize(enum_type : T.class, @values : Indexable(U)); end
 
@@ -63,6 +36,30 @@ struct Enum::Mapping(T, U)
   end
 end
 
+# Defines a enum where each member holds a reference to an associated value.
+#
+# This may be used to define enum over non-integer types, whilst keeping the
+# same type safety that integer-backed enums provide.
+#
+# ```
+# mapped_enum Example do
+#   A = "foo"
+#   B = "bar"
+#   C = "baz"
+# end
+# ```
+#
+# Instances may be read from mapped values
+# ```
+# Example["foo"] # => Example::A
+# ```
+#
+# Mapped values may also be extracted
+# ```
+# Example::A.mapped_value # => "foo"
+# ```
+#
+# All other functionality, performance and safety that enums provide holds.
 macro mapped_enum(name, &block)
   {% begin %}
     {% enum_type = name.id %}

--- a/src/macro/mapped_enum.cr
+++ b/src/macro/mapped_enum.cr
@@ -1,6 +1,6 @@
 # Annotation for attaching arbitrary value mappings to Enum types.
 #
-# When applied, a positional arg must exist for each enum meber
+# When applied, a positional arg must exist for each enum member
 # ```
 # @[MappedValues("foo", "bar", 42)]
 # enum Foo

--- a/src/macro/mapped_enum.cr
+++ b/src/macro/mapped_enum.cr
@@ -25,11 +25,6 @@
 # Example::A.mapped_value # => "foo"
 # ```
 #
-# A short form is also provided
-# ```
-# ~Example::A # => "foo"
-# ```
-#
 # All other functionality, performance and safety that enums provide holds.
 macro mapped_enum(name, *members, &block)
   {% begin %}
@@ -116,11 +111,6 @@ macro mapped_enum(name, *members, &block)
           in {{type_name}}::{{member.target.id}} then {{member.value}}
         {% end %}
         end
-      end
-
-      # :ditto:
-      def ~
-        mapped_value
       end
 
       {% if block %}

--- a/src/macro/mapped_enum.cr
+++ b/src/macro/mapped_enum.cr
@@ -1,0 +1,131 @@
+# Defines a enum where each member holds a reference to an associated value.
+#
+# This may be used to define enum over non-integer types, whilst keeping the
+# same type safety that integer-backed enums provide.
+#
+# ```
+# mapped_enum Example(String),
+#   A = "foo",
+#   B = "bar",
+#   C = "baz"
+# ```
+#
+# Instances may be read from mapped values
+# ```
+# Example.from_mapped_value "foo" # => Example::A
+# ```
+#
+# A short-form syntax is also available for this
+# ```
+# Example["foo"] # => Example::A
+# ```
+#
+# Mapped values may also be extracted
+# ```
+# Example::A.mapped_value # => "foo"
+# ```
+#
+# A short form is also provided
+# ```
+# ~Example::A # => "foo"
+# ```
+#
+# All other functionality, performance and safety that enums provide holds.
+macro mapped_enum(name, *members, &block)
+  {% begin %}
+    {% if name.is_a? Generic %}
+      {% type_name = name.name.id %}
+      {% mapped_type = name.type_vars[0].id %}
+      {% strict = true %}
+    {% else %}
+      {% type_name = name.id %}
+      {% strict = false %}
+    {% end %}
+    enum {{type_name}}
+      {% for member in members %}
+        {{member.target.id}}
+      {% end %}
+
+      # Returns the enum member that has the given mapped value, or yields if no
+      # such member exists.
+      {% if strict %}
+        def self.from_mapped_value(value : {{mapped_type}}, & : {{mapped_type}} -> T) : self | T forall T
+      {% else %}
+        def self.from_mapped_value(value, &)
+      {% end %}
+        case value
+        {% for member in members %}
+          when {{member.value}} then {{type_name}}::{{member.target.id}}
+        {% end %}
+        else
+          yield value
+        end
+      end
+
+      # Returns the enum member that has the given mapped value, or raises if no
+      # such member exists.
+      {% if strict %}
+        def self.from_mapped_value(value : {{mapped_type}}) : self
+      {% else %}
+        def self.from_mapped_value(value) : self
+      {% end %}
+        from_mapped_value(value) { raise "Unmapped value for enum #{self}: #{value}" }
+      end
+
+      # :ditto:
+      {% if strict %}
+        def self.[](value : {{mapped_type}}) : self
+      {% else %}
+        def self.[](value) : self
+      {% end %}
+        from_mapped_value value
+      end
+
+      # Returns the enum member that has the given mapped value, or `nil` if no
+      # such member exists.
+      {% if strict %}
+        def self.from_mapped_value?(value : {{mapped_type}}) : self?
+      {% else %}
+        def self.from_mapped_value?(value) : self?
+      {% end %}
+        from_mapped_value(value) { nil }
+      end
+
+      # :ditto:
+      {% if strict %}
+        def self.[]?(value : {{mapped_type}}) : self?
+      {% else %}
+        def self.[]?(value) : self?
+      {% end %}
+        from_mapped_value? value
+      end
+
+      # Returns the `Tuple` of all mapped values.
+      def self.mapped_values
+        {{members.map &.value}}
+      end
+
+      # Returns the value mapped to `self`.
+      {% if strict %}
+        def mapped_value : {{mapped_type}}
+      {% else %}
+        def mapped_value
+      {% end %}
+        case self
+        {% for member in members %}
+          in {{type_name}}::{{member.target.id}} then {{member.value}}
+        {% end %}
+        end
+      end
+
+      # :ditto:
+      def ~
+        mapped_value
+      end
+
+      {% if block %}
+        {{block.body}}
+      {% end %}
+    end
+  {% end %}
+end


### PR DESCRIPTION
Provides support for defining non-integer enum types.
```crystal
mapped_enum Example do
  A = "foo"
  B = "bar"
  C = "baz"
end
```

Instances may be read from mapped values
```crystal
Example["foo"] # => Example::A
```

Mapped values may also be extracted
```crystal
Example::A.mapped_value # => "foo"
```

All other functionality and safety that enums provide holds.