### PR TITLE
feat: `Hash(K,V).with_default`

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,4 +110,25 @@ my_hash = {} of String => String
 my_hash = my_hash.presence || {"default" => "settings"}
 ```
 
+### `with_default`
 
+Provides `Hash(K,V).with_default`
+
+Creates a `Hash(K,V)` with a default for missing keys with the result of a yielded block.
+Includes a pun of `Hash(K,V).new(default_value : V, initial_capacity = nil)`
+
+```crystal
+require "inactive-support/with_default/hash"
+# or...
+# require "inactive-support/with_default"
+
+block_default = Hash(String, Array(Int32).with_default { ["bye"] }
+block_default.empty? # => true
+block_default["hello"] # => ["bye"]
+block_default["a"] == block_default["b"] # => false
+
+value_default = Hash(String, Array(Int32).with_default ["bye"]
+value_default.empty? # => true
+value_default["hello"] # => ["bye"]
+value_default["a"] == value_default["b"] # => true
+```

--- a/spec/with_default/hash_spec.cr
+++ b/spec/with_default/hash_spec.cr
@@ -1,0 +1,20 @@
+require "spec"
+require "../../src/with_default/hash"
+
+describe "with_default/hash" do
+  describe "Hash(K,V).with_default" do
+    it "creates defaults for missing keys with a value" do
+      hash = Hash(String, Int32).with_default(5)
+      hash.should be_empty
+      hash["1"].should eq 5
+    end
+
+    it "creates defaults for missing keys with a block" do
+      hash = Hash(String, Array(Int32)).with_default { [] of Int32 }
+      hash.should be_empty
+      array1 = hash["1"]
+      array2 = hash["2"]
+      array1.should_not be array2
+    end
+  end
+end

--- a/src/with_default/hash.cr
+++ b/src/with_default/hash.cr
@@ -1,0 +1,11 @@
+class Hash(K, V)
+  def self.with_default(initial_capacity : Int32? = nil, &block : -> V) : Hash(K, V)
+    Hash(K, V).new(initial_capacity: initial_capacity) do |hash, key|
+      hash[key] = block.call
+    end
+  end
+
+  def self.with_default(default : V, initial_capacity : Int32? = nil) : Hash(K, V)
+    with_default(initial_capacity: initial_capacity) { default }
+  end
+end

--- a/src/with_default/with_default.cr
+++ b/src/with_default/with_default.cr
@@ -1,0 +1,1 @@
+require "./hash"


### PR DESCRIPTION
It's very common to create a hash with a default value based on a block. 
The current syntax in crystal expects you to set the key in the hash, like so

```crystal
block_default = Hash(String, Array(Int32)).new { |hash, key| hash[key] = ["bye"] }
block_default.empty? # => true
block_default["hello"] # => ["bye"]
block_default["a"] == block_default["b"] # => false
```

I propose the helper, `.with_default`

```crystal
require "inactive-support/with_default/hash"
# or require "inactive-support/with_default"

block_default = Hash(String, Array(Int32).with_default { ["bye"] }
block_default.empty? # => true
block_default["hello"] # => ["bye"]
block_default["a"] == block_default["b"] # => false

# Includes a pun of `Hash(K,V).new(default_value : V, initial_capacity = nil)` 
value_default = Hash(String, Array(Int32).with_default ["bye"]
value_default.empty? # => true
value_default["hello"] # => ["bye"]
value_default["a"] == value_default["b"] # => true
```