### PR TITLE
ci: remove os, add `style` job, clearer names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,8 @@ jobs:
       matrix:
         stable: [true]
         crystal:
-          - 1.1.0
           - 1.0.0
-          - 0.36.1
+          - latest
         include:
           - stable: false
             crystal: nightly

--- a/.github/workflows/crystal.yml
+++ b/.github/workflows/crystal.yml
@@ -15,8 +15,6 @@ jobs:
         run: crystal tool format --check
       - name: Lint
         uses: crystal-ameba/github-action@v0.2.12
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   test:
     strategy:
@@ -32,9 +30,11 @@ jobs:
             crystal: nightly
     name: "crystal: ${{ matrix.crystal }}, stable: ${{ matrix.stable }}"
     runs-on: ubuntu-latest
-    container: crystallang/crystal:${{ matrix.crystal }}-alpine
     continue-on-error: ${{ !matrix.stable }}
     steps:
+      - uses: oprypin/install-crystal@v1
+        with:
+          crystal: ${{ matrix.crystal }}
       - uses: actions/checkout@v2
       - name: Run tests
         run: crystal spec -v --error-trace

--- a/.github/workflows/crystal.yml
+++ b/.github/workflows/crystal.yml
@@ -20,6 +20,7 @@ jobs:
 
   test:
     strategy:
+      fail-fast: false
       matrix:
         stable: [true]
         crystal:

--- a/.github/workflows/crystal.yml
+++ b/.github/workflows/crystal.yml
@@ -19,6 +19,7 @@ jobs:
         include:
           - experimental: true
             crystal: nightly
+    name: "crystal: ${{ matrix.crystal }}, unstable: ${{ matrix.experimental }}"
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }}
     container: crystallang/crystal:${{ matrix.crystal }}-alpine

--- a/.github/workflows/crystal.yml
+++ b/.github/workflows/crystal.yml
@@ -7,7 +7,19 @@ on:
     - cron: "0 6 * * 1"
 
 jobs:
-  build:
+  style:
+    runs-on: ubuntu-latest
+    container: crystallang/crystal
+    steps:
+      - uses: actions/checkout@v2
+      - name: Format
+        run: crystal tool format --check
+      - name: Lint
+        uses: crystal-ameba/github-action@v0.2.12
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  test:
     strategy:
       fail-fast: false
       matrix:
@@ -25,7 +37,5 @@ jobs:
     container: crystallang/crystal:${{ matrix.crystal }}-alpine
     steps:
     - uses: actions/checkout@v2
-    - name: Format
-      run: crystal tool format --check
     - name: Run tests
       run: crystal spec -v --error-trace

--- a/.github/workflows/crystal.yml
+++ b/.github/workflows/crystal.yml
@@ -12,16 +12,14 @@ jobs:
       fail-fast: false
       matrix:
         experimental: [false]
-        os: [ubuntu-latest]
         crystal:
           - latest
           - 1.0.0
           - 0.36.1
         include:
           - experimental: true
-            os: ubuntu-latest
             crystal: nightly
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }}
     container: crystallang/crystal:${{ matrix.crystal }}-alpine
     steps:

--- a/.github/workflows/crystal.yml
+++ b/.github/workflows/crystal.yml
@@ -2,7 +2,6 @@ name: CI
 
 on:
   push:
-  workflow_dispatch:
   schedule:
     - cron: "0 6 * * 1"
 
@@ -21,24 +20,23 @@ jobs:
 
   test:
     strategy:
-      fail-fast: false
       matrix:
-        experimental: [false]
+        stable: [true]
         crystal:
-          - latest
+          - 1.1.0
           - 1.0.0
           - 0.36.1
         include:
-          - experimental: true
+          - stable: false
             crystal: nightly
-    name: "crystal: ${{ matrix.crystal }}, unstable: ${{ matrix.experimental }}"
+    name: "crystal: ${{ matrix.crystal }}, stable: ${{ matrix.stable }}"
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.experimental }}
     container: crystallang/crystal:${{ matrix.crystal }}-alpine
+    continue-on-error: ${{ !matrix.stable }}
     steps:
-    - uses: actions/checkout@v2
-    - name: Run tests
-      run: crystal spec -v --error-trace
+      - uses: actions/checkout@v2
+      - name: Run tests
+        run: crystal spec -v --error-trace
 
   publish:
     if: contains('refs/tags', github.ref)

--- a/.github/workflows/crystal.yml
+++ b/.github/workflows/crystal.yml
@@ -39,3 +39,21 @@ jobs:
     - uses: actions/checkout@v2
     - name: Run tests
       run: crystal spec -v --error-trace
+
+  publish:
+    if: contains('refs/heads/master', github.ref)
+    runs-on: ubuntu-latest
+    container: crystallang/crystal:latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: shards install --ignore-crystal-version
+      - name: Run `crystal docs`
+        run: crystal docs
+      - name: Publish to GitHub Pages
+        uses: crazy-max/ghaction-github-pages@v2
+        with:
+          target_branch: docs
+          build_dir: docs
+          commit_message: "docs: update for ${{ github.sha }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/crystal.yml
+++ b/.github/workflows/crystal.yml
@@ -41,7 +41,7 @@ jobs:
       run: crystal spec -v --error-trace
 
   publish:
-    if: contains('refs/heads/master', github.ref)
+    if: contains('refs/tags', github.ref)
     runs-on: ubuntu-latest
     container: crystallang/crystal:latest
     steps:
@@ -54,6 +54,6 @@ jobs:
         with:
           target_branch: docs
           build_dir: docs
-          commit_message: "docs: update for ${{ github.sha }}"
+          commit_message: "docs: update for ${{ github.ref }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Inactive Support
 
+[![GitHub Actions](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2Fspider-gazelle%2Finactive-support%2Fbadge&label=Tests&logo=none)](https://github.com/spider-gazelle/inactive-support/actions/workflows/crystal.yml)
+[![Documentation](https://img.shields.io/badge/Documentation-available-brightgreen.svg)](https://spider-gazelle.github.io/inactive-support)
+
 A collection of classes, modules, macros and standard library extensions to simplify common tasks in crystal-lang.
 
 Each tool is small, independent and generic.


### PR DESCRIPTION
- removes `os` from test matrix
- creates `style` job
- generates clearer names for test jobs
- autogenerated documentation

Closes #9